### PR TITLE
USB-Audio: ALC4080 on Gigabyte Z690 AORUS ULTRA

### DIFF
--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -46,6 +46,7 @@ If.realtek-alc4080 {
 		String "${CardComponents}"
 		# 0414:a00e Gigabyte Z590 Aorus Pro AX
 		# 0414:a010 Gigabyte Z590 Vision G Intel
+		# 0414:a011 Gigabyte Z690 AORUS ULTRA
 		# 0414:a012 Gigabyte Z690 AERO G DDR4
 		# 0b05:1984 ASUS Pro WS WRX80E-SAGE SE WIFI
 		# 0b05:1996 ASUS on multiple boards (including ASUS ROG Maximus XIII)
@@ -76,7 +77,7 @@ If.realtek-alc4080 {
 		# 0db0:b202 MSI MAG Z690 Tomahawk Wifi
 		# 0db0:d1d7 MSI PRO Z790-A WIFI
 		# 0db0:d6e7 MSI MPG X670E Carbon Wifi
-		Regex "USB((0414:a0(0e|1[02]))|(0b05:(19(84|9[69])|1a(16|2[07]|5[23])))|(0db0:(005a|151f|1feb|3130|36e7|419c|422d|4240|62a4|6c[0c]9|7696|82c7|8af7|961e|a073|a47c|a74b|b202|d1d7|d6e7)))"
+		Regex "USB((0414:a0(0e|1[012]))|(0b05:(19(84|9[69])|1a(16|2[07]|5[23])))|(0db0:(005a|151f|1feb|3130|36e7|419c|422d|4240|62a4|6c[0c]9|7696|82c7|8af7|961e|a073|a47c|a74b|b202|d1d7|d6e7)))"
 	}
 	True.Define.ProfileName "Realtek/ALC4080"
 }


### PR DESCRIPTION
This PR adds the USB ID of the ALC4080 found in the [Z690 AORUS ULTRA](https://www.gigabyte.com/Motherboard/Z690-AORUS-ULTRA-rev-1x/sp#sp), `0414:a011`.